### PR TITLE
Feature/#8 bookshelf detail get api

### DIFF
--- a/src/constants/responseMessage.ts
+++ b/src/constants/responseMessage.ts
@@ -38,6 +38,8 @@ export default {
   // 책장
   CREATE_MYBOOK_SUCCESS: "책 등록 성공",
   CREATE_MYBOOK_FAIL: "책 등록 실패",
+  READ_MYBOOK_SUCCESS: "등록된 책 상세 조회 성공",
+  READ_MYBOOK_FAIL: "해당하는 책을 찾을 수 없습니다.",
 
   // 서버 내 오류
   INTERNAL_SERVER_ERROR: "서버 내 오류",

--- a/src/controller/bookshelfController.ts
+++ b/src/controller/bookshelfController.ts
@@ -24,8 +24,25 @@ const createMybook = async (req: Request, res: Response) => {
     return res.status(sc.CREATED).send(success(sc.CREATED, rm.CREATE_MYBOOK_SUCCESS, result)); 
 };
 
+/**
+ * @route GET /bookshelf/detail?bookId={}
+ * @desc 등록한 책의 상세 정보 불러오기
+ */
+const getBookById = async (req: Request, res: Response) => {
+
+    const { bookId } = req.params;
+
+    const data = await bookshelfService.getBookById(+bookId); 
+
+    if (!data) {
+        return res.status(sc.NOT_FOUND).send(fail(sc.NOT_FOUND, rm.READ_MYBOOK_FAIL));
+    }
+    return res.status(sc.OK).send(success(sc.OK, rm.READ_MYBOOK_SUCCESS, data));
+}
+
 const bookshelfController = {
-    createMybook
+    createMybook,
+    getBookById
 };
   
 export default bookshelfController;

--- a/src/controller/bookshelfController.ts
+++ b/src/controller/bookshelfController.ts
@@ -25,7 +25,7 @@ const createMybook = async (req: Request, res: Response) => {
 };
 
 /**
- * @route GET /bookshelf/detail?bookId={}
+ * @route GET /bookshelf/detail/:bookId
  * @desc 등록한 책의 상세 정보 불러오기
  */
 const getBookById = async (req: Request, res: Response) => {

--- a/src/interfaces/bookshelf/BookResDTO.ts
+++ b/src/interfaces/bookshelf/BookResDTO.ts
@@ -1,7 +1,0 @@
-export interface BookResDTO {
-    bookImage : string,
-    bookTitle : string,
-    author : string,
-    description : string,
-    memo : string
-}

--- a/src/interfaces/bookshelf/BookResDTO.ts
+++ b/src/interfaces/bookshelf/BookResDTO.ts
@@ -1,0 +1,7 @@
+export interface BookResDTO {
+    bookImage : string,
+    bookTitle : string,
+    author : string,
+    description : string,
+    memo : string
+}

--- a/src/router/bookshelfRouter.ts
+++ b/src/router/bookshelfRouter.ts
@@ -7,7 +7,7 @@ const router: Router = Router();
 //* 내 책장에 책 등록하기 POST /bookshelf
 router.post("/", bookshelfController.createMybook);
 
-//* 등록한 책 상세 정보 불러오기 GET /bookshelf/detail?bookId={}
-router.get("/detail", bookshelfController.getBookById);
+//* 등록한 책 상세 정보 불러오기 GET /bookshelf/detail/:bookId
+router.get("/detail/:bookId", bookshelfController.getBookById);
 
 export default router;

--- a/src/router/bookshelfRouter.ts
+++ b/src/router/bookshelfRouter.ts
@@ -7,4 +7,7 @@ const router: Router = Router();
 //* 내 책장에 책 등록하기 POST /bookshelf
 router.post("/", bookshelfController.createMybook);
 
+//* 등록한 책 상세 정보 불러오기 GET /bookshelf/detail?bookId={}
+router.get("/detail", bookshelfController.getBookById);
+
 export default router;

--- a/src/service/bookshelfService.ts
+++ b/src/service/bookshelfService.ts
@@ -48,8 +48,31 @@ const createMybook = async (bookshelfCreateDto : BookshelfCreateDTO) => {
   return data;
 };
 
+//* 등록한 책 상세 정보 조회
+const getBookById = async (bookId: number)=> {
+  const bookData = await prisma.bookshelf.findUnique({
+    where: {
+      id: bookId
+    },
+    select : {
+      description : true,
+      memo : true,
+      Book : {
+        select : {
+          bookImage : true,
+          bookTitle : true,
+          author : true
+        }
+      }
+    }
+  });
+
+  return bookData;
+};
+
 const bookshelfService = {
-    createMybook
+    createMybook,
+    getBookById
 };
 
 export default bookshelfService;

--- a/src/service/bookshelfService.ts
+++ b/src/service/bookshelfService.ts
@@ -50,9 +50,11 @@ const createMybook = async (bookshelfCreateDto : BookshelfCreateDTO) => {
 
 //* 등록한 책 상세 정보 조회
 const getBookById = async (bookId: number)=> {
-  const bookData = await prisma.bookshelf.findUnique({
+  const bookData = await prisma.bookshelf.findFirst({
     where: {
-      id: bookId
+      bookId : bookId,
+      // 일단 userId 박아두고 작업
+      userId : 1
     },
     select : {
       description : true,


### PR DESCRIPTION
### ⭐ Related Issue
* closed #8 

### 📌 Work description
* 책장에 등록한 책의 상세 정보 조회하기

### ✔️ Questioon & PR point
* bookId는 query로 받는 것보다는 path parameter로 받는 게 나을 것 같아 API 명세서 수정 완료 했습니다 !
* userId와 bookId 두 가지 모두로 bookshelf 테이블에서 탐색해야함. _(현재는 userId 1로 고정)_

👇 bookshelf 테이블에 없는 bookid를 줬을 때

![image](https://user-images.githubusercontent.com/68415644/210670483-25a83684-5010-4a0f-acb8-46c1f8dc61ab.png)

👇 bookshelf 테이블에 있는 bookid를 줬을 때

![image](https://user-images.githubusercontent.com/68415644/210670911-b55bc05f-7941-4bd3-811f-9e8d65d920db.png)

