### PR TITLE
#219 [FIX] 차단한 유저 검색이 안되도록 로직 수정

### DIFF
--- a/src/service/friendService.ts
+++ b/src/service/friendService.ts
@@ -115,8 +115,9 @@ const searchUser = async (nickname: string, auth: number) => {
         }
     });
 
+    //* 차단하면 사용자 검색이 아예 안되도록
     if (block != null) {
-        isBlocked = true;
+        return null;
     }
 
     const followed = await prisma.friend.findFirst({


### PR DESCRIPTION
### ⭐ Related Issue
* closed #219 

### 📌 Work description
* 차단한 유저는 검색 자체가 안되도록 수정

### ✔️ Questioon & PR point
* 
